### PR TITLE
Updated Dockerfile to support YLT server v1.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apk upgrade --update && apk --no-cache add git gcc make g++ zlib-dev libjpeg
   && echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" > /etc/apk/repositories \
   && echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
   && echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
-  && echo "http://dl-cdn.alpinelinux.org/alpine/v3.12/main" >> /etc/apk/repositories \
   && apk upgrade -U -a \
   && apk add \
     libjpeg-turbo-dev \


### PR DESCRIPTION
I have update the Dockerfile to support the most recent version of [YellowLabTools](https://github.com/YellowLabTools/YellowLabTools-server/tree/develop).

- Updated NPM install script to use `--legacy-peer-deps` due to a mismatch in peer-dependencies on `YellowLabTools-server` (namely `"grunt": "~1.0.4"` and `"grunt-inline-angular-template": "^0.1.5"`
- Updated to `node:18-alpine` image
- Created temporary directories required for Chromium write access
- Correctly configured owner on `/usr/src/ylt/results` folder