### PR TITLE
Setup GitHub actions to build & publish Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 # This worksflow builds the Docker image as part of the CI process
 
-name: Docker Image CI
+name: Build
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout the repository
-    - uses: actions/checkout@v3
+      uses: actions/checkout@v4
     
     - name: Build the Docker image
       run: docker build . --tag yellowlabtools:$(date +%s)

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,7 +4,7 @@
 # - secrets.DOCKER_USERNAME
 # - secrets.DOCKER_PASSWORD
 # - secrets.DOCKER_REPOSITORY
-name: Docker Image CI
+name: Publish Docker Image
 
 on:
   release:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The official Yellow Lab Tools v2 image
+# The official Yellow Lab Tools v3 image
 [`Yellow Lab Tools`](https://github.com/YellowLabTools/YellowLabTools) is an open source project developed by Gaël Métais.
 It analyzes a webpage and detects **performance** or **front-end code quality** issues. Free, easy to launch, easy to understand, in-depth details. With this docker image, you can run your own YellowLabTools instance.
 This image will be updated continuously.
@@ -31,4 +31,4 @@ replace http://localhost:8080/ by http://host.docker.internal:8080/
 - Gaël Métais [gmetais](https://github.com/gmetais)
 - Bruno Alimelie [baconsulting](https://github.com/baconsulting)
 - Alexandre Painchaud [painchaudAlexandre](https://github.com/painchaudAlexandre)
-- kevinfarrugia [kevinfarrugia](https://github.com/kevinfarrugia)
+- Kevin Farrugia [kevinfarrugia](https://github.com/kevinfarrugia)


### PR DESCRIPTION
This PR introduces two GitHub actions. 
- `build.yml` is used to build the Docker image on each pull request or commit to `main`. This helps check that the dockerfile does not contain any bugs.
- `docker-image.yml` is used to publish the Docker image to Docker Hub. The login and repository need to be configured as GitHub repository secrets.

The PR also updates the README.md title to V3. 🎉

**ATTN:**

Before merging this pull request, you are required to create the following GitHub Repository Secrets:

```
- secrets.DOCKER_USERNAME
- secrets.DOCKER_PASSWORD
- secrets.DOCKER_REPOSITORY
```

The `DOCKER_USERNAME` and `DOCKER_PASSWORD` may be retrieved after logging in to Docker Hub and creating an Access Token. The `DOCKER_REPOSITORY` is `ousamabenyounes/yellowlabtools`

I was able to test the GitHub actions, including publishing to Docker Hub using a [fork](https://hub.docker.com/r/imkevdev/yellowlabtools). Once the official image is updated on Docker Hub I will remove my own to avoid confusion.