### PR TITLE
Update Usage command to run in interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This image will be updated continuously.
 ## Usage
 
 ```sh
-docker run --privileged -p 8383:8383 ousamabenyounes/yellowlabtools 
+docker run -it --privileged -p 8383:8383 ousamabenyounes/yellowlabtools 
 ```
 
 or if you prefer to run it in detached mode add the `-d` option:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ docker run -d --privileged -p 8383:8383 ousamabenyounes/yellowlabtools
 
 And then open [`http://localhost:8383/`](http://localhost:8383/) on your web browser.  
 
+### localhost
+
+If you would like to run tests against a website that is only available on the host network, for example, `localhost`, then you need to run the Docker image using the `--network=host` flag.
+
+```diff
+- docker run -it --privileged -p 8383:8383 ousamabenyounes/yellowlabtools
++ docker run -it --privileged --network host -p 8383:8383 ousamabenyounes/yellowlabtools 
+```
+
 ## Debug
 
 If you need to run your instance in debug mode, add `'DEBUG=*` to the environment variables:


### PR DESCRIPTION
`-t` is required to allocate a pseudo-tty
`-i` is required to keep `stdin` open

This makes it easier for a user to interact with the Docker process (for example, to exit interactive mode without stopping the Docker process)